### PR TITLE
Using microseconds(u) instead milliseconds(v)

### DIFF
--- a/src/TimeSpan.php
+++ b/src/TimeSpan.php
@@ -18,7 +18,7 @@ final readonly class TimeSpan
 
     public static function diff(\DateTimeImmutable $a, \DateTimeImmutable $b): self
     {
-        return new self((int) $a->format('Uv') - (int) $b->format('Uv'));
+        return new self((int) $a->format('Uu') - (int) $b->format('Uu'));
     }
 
     public static function from(


### PR DESCRIPTION
https://www.php.net/manual/en/datetime.format.php#:~:text=u,Microseconds