### PR TITLE
Make TimeSpan::__construct() public

### DIFF
--- a/src/TimeSpan.php
+++ b/src/TimeSpan.php
@@ -135,8 +135,8 @@ final readonly class TimeSpan
         return $timeSpan;
     }
 
-    private function __construct(
-        private int $nanoseconds,
+    public function __construct(
+        private int $nanoseconds = 0,
     ) {}
 
     public function toNanoseconds(): int

--- a/tests/TimeSpanTest.php
+++ b/tests/TimeSpanTest.php
@@ -179,6 +179,20 @@ final class TimeSpanTest extends TestCase
         TimeSpan::fromInterval($interval);
     }
 
+    #[TestWith([0])]
+    #[TestWith([100])]
+    #[TestWith([-100])]
+    #[TestWith([PHP_INT_MAX])]
+    #[TestWith([PHP_INT_MIN])]
+    #[TestWith([9_223_372_036_854_775_000])]
+    #[TestWith([-9_223_372_036_854_775_000])]
+    public function testConstructor(int $nanoseconds): void
+    {
+        $span = new TimeSpan($nanoseconds);
+
+        self::assertSame($nanoseconds, $span->toNanoseconds());
+    }
+
     #[TestWith([0, 0])]
     #[TestWith([0.0, 0])]
     #[TestWith([100, 100])]

--- a/tests/TimeSpanTest.php
+++ b/tests/TimeSpanTest.php
@@ -193,6 +193,13 @@ final class TimeSpanTest extends TestCase
         self::assertSame($nanoseconds, $span->toNanoseconds());
     }
 
+    public function testConstructorWithoutArgs(): void
+    {
+        $span = new TimeSpan();
+
+        self::assertSame(0, $span->toNanoseconds());
+    }
+
     #[TestWith([0, 0])]
     #[TestWith([0.0, 0])]
     #[TestWith([100, 100])]


### PR DESCRIPTION
This is useful for default values:

```php
function send(object $message, TimeSpan $delay = new TimeSpan()) {
    // ...
}
```